### PR TITLE
Add message formatting to Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,31 @@ def test_code_with_error():
     assert_error(MyVisitor, 'class Y: pass', MyError)
 
 def test_code_without_error():
-    assert_not_error(MyVisitor, 'x = 1)
+    assert_not_error(MyVisitor, 'x = 1')
+```
+
+### Formatting
+
+Your `Error`s can take formatting arguments in their `message`:
+
+```python
+from flake8_plugin_utils import Error, Visitor, assert_error
+
+class MyFormattedError(Error):
+    code = 'X101'
+    message = 'my error with {thing}'
+
+class MyFormattedVisitor(Visitor):
+    def visit_ClassDef(self, node):
+        self.error_from_node(MyFormattedError, node, thing=node.name)
+
+def test_code_with_error():
+    assert_error(
+        MyFormattedVisitor,
+        'class Y: pass',
+        MyFormattedError,
+        thing='Y',
+    )
 ```
 
 ## License
@@ -54,6 +78,10 @@ def test_code_without_error():
 MIT
 
 ## Change Log
+
+### Unreleased
+
+* add message formatting to Error
 
 ### 0.2.1 - 2019-04-01
 

--- a/flake8_plugin_utils/plugin.py
+++ b/flake8_plugin_utils/plugin.py
@@ -1,6 +1,6 @@
 import ast
 import re
-from typing import Iterable, List, Tuple, Type
+from typing import Any, Iterable, List, Tuple, Type
 
 FLAKE8_ERROR = Tuple[int, int, str, 'Plugin']
 NOQA_REGEXP = re.compile(r'#.*noqa\s*($|[^:\s])', re.I)
@@ -13,17 +13,24 @@ class Error:
     lineno: int
     col_offset: int
 
-    def __init__(self, lineno: int, col_offset: int) -> None:
+    def __init__(self, lineno: int, col_offset: int, **kwargs: Any) -> None:
         self.lineno = lineno
         self.col_offset = col_offset
+        self.message = self.formatted_message(**kwargs)
+
+    @classmethod
+    def formatted_message(cls, **kwargs: Any) -> str:
+        return cls.message.format(**kwargs)
 
 
 class Visitor(ast.NodeVisitor):
     def __init__(self) -> None:
         self.errors: List[Error] = []
 
-    def error_from_node(self, error: Type[Error], node: ast.AST) -> None:
-        self.errors.append(error(node.lineno, node.col_offset))
+    def error_from_node(
+        self, error: Type[Error], node: ast.AST, **kwargs: Any
+    ) -> None:
+        self.errors.append(error(node.lineno, node.col_offset, **kwargs))
 
 
 class Plugin:

--- a/flake8_plugin_utils/utils.py
+++ b/flake8_plugin_utils/utils.py
@@ -1,6 +1,6 @@
 import ast
 from textwrap import dedent
-from typing import Optional, Type
+from typing import Any, Optional, Type
 
 from .plugin import Error, Visitor
 
@@ -32,11 +32,16 @@ def _error_from_src(visitor_cls: Type[Visitor], src: str) -> Optional[Error]:
 
 
 def assert_error(
-    visitor_cls: Type[Visitor], src: str, expected: Type[Error]
+    visitor_cls: Type[Visitor], src: str, expected: Type[Error], **kwargs: Any
 ) -> None:
     err = _error_from_src(visitor_cls, src)
     assert err, f'Error "{expected.message}" not found in\n{src}'
     assert isinstance(err, expected)
+
+    expected_message = expected.formatted_message(**kwargs)
+    assert (
+        expected_message == err.message
+    ), f'Expected error with message "{expected_message}", got "{err.message}"'
 
 
 def assert_not_error(visitor_cls: Type[Visitor], src: str) -> None:


### PR DESCRIPTION
The idea is to make `Error.message` a formatting string (`{}`-style) and add formatting arguments as optional keyword arguments of `Error.__init__` and `Visitor.error_from_node`

```
from flake8_plugin_utils import Error, Visitor, assert_error

class MyFormattedError(Error):
    code = 'X101'
    message = 'my error with {thing}'

class MyFormattedVisitor(Visitor):
    def visit_ClassDef(self, node):
        self.error_from_node(MyFormattedError, node, thing=node.name)

def test_code_with_error():
    assert_error(
        MyFormattedVisitor,
        'class Y: pass',
        MyFormattedError,
        thing='Y',
    )
```