### PR TITLE
[WIP] Add ConfigurablePlugin

### DIFF
--- a/flake8_plugin_utils/__init__.py
+++ b/flake8_plugin_utils/__init__.py
@@ -1,2 +1,11 @@
-from .plugin import Error, Plugin, Visitor  # noqa:F401
-from .utils import assert_error, assert_not_error, is_none  # noqa:F401
+from .plugin import Error, Plugin, Visitor
+from .utils import assert_error, assert_not_error, is_none
+
+__all__ = (
+    'Error',
+    'Plugin',
+    'Visitor',
+    'assert_error',
+    'assert_not_error',
+    'is_none',
+)

--- a/flake8_plugin_utils/plugin.py
+++ b/flake8_plugin_utils/plugin.py
@@ -1,7 +1,7 @@
 import argparse
 import ast
 import re
-from typing import Any, Generic, Iterable, List, Tuple, Type, TypeVar
+from typing import Any, ClassVar, Generic, Iterable, List, Tuple, Type, TypeVar
 
 from flake8.options.manager import OptionManager
 
@@ -96,7 +96,7 @@ class ConfigurableVisitor(Generic[TConfig], Visitor):
 class ConfigurablePlugin(
     Generic[TConfig], BasePlugin[ConfigurableVisitor[TConfig]]
 ):
-    config: TConfig
+    config: ClassVar[TConfig]
 
     @classmethod
     def add_options(cls, option_manager: OptionManager) -> None:


### PR DESCRIPTION
Intended usage:

* Create a config class `MyConfig` for plugin
* Inherit plugin from `ConfigurablePlugin[MyConfig]`
* Inherit visitors from `ConfigurableVisitor[MyConfig]`
* Use `self.config` in visitor code

`ConfigurableVisitor`s are easily testable because they receive the config in constructor.

Readme and tests will follow if you approve of the general idea.