### PR TITLE
Add ability for plugins to parse and use config

### DIFF
--- a/flake8_plugin_utils/__init__.py
+++ b/flake8_plugin_utils/__init__.py
@@ -1,2 +1,11 @@
-from .plugin import Error, Plugin, Visitor  # noqa:F401
-from .utils import assert_error, assert_not_error, is_none  # noqa:F401
+from .plugin import Error, Plugin, Visitor
+from .utils import assert_error, assert_not_error, is_none
+
+__all__ = (
+    'Error',
+    'Plugin',
+    'Visitor',
+    'assert_error',
+    'assert_not_error',
+    'is_none',
+)

--- a/flake8_plugin_utils/plugin.py
+++ b/flake8_plugin_utils/plugin.py
@@ -1,10 +1,26 @@
+import argparse
 import ast
 import re
-from typing import Any, Iterable, List, Tuple, Type
+from contextlib import contextmanager
+from typing import (
+    Any,
+    Generic,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+)
+
+from flake8.options.manager import OptionManager
 
 FLAKE8_ERROR = Tuple[int, int, str, 'Plugin']
 NOQA_REGEXP = re.compile(r'#.*noqa\s*($|[^:\s])', re.I)
 NOQA_ERROR_CODE_REGEXP = re.compile(r'#.*noqa\s*:\s*(\w+)', re.I)
+
+TConfig = TypeVar('TConfig')
 
 
 class Error:
@@ -23,9 +39,19 @@ class Error:
         return cls.message.format(**kwargs)
 
 
-class Visitor(ast.NodeVisitor):
-    def __init__(self) -> None:
+class Visitor(Generic[TConfig], ast.NodeVisitor):
+    def __init__(self, config: Optional[TConfig] = None) -> None:
         self.errors: List[Error] = []
+        self._config: Optional[TConfig] = config
+
+    @property
+    def config(self) -> TConfig:
+        if self._config is None:
+            raise TypeError(
+                f'{self} was initialized without a config.  Did you forget '
+                f'to override parse_options_to_config in your plugin class?'
+            )
+        return self._config
 
     def error_from_node(
         self, error: Type[Error], node: ast.AST, **kwargs: Any
@@ -33,10 +59,11 @@ class Visitor(ast.NodeVisitor):
         self.errors.append(error(node.lineno, node.col_offset, **kwargs))
 
 
-class Plugin:
+class Plugin(Generic[TConfig]):
     name: str
     version: str
-    visitors: List[Type[Visitor]]
+    visitors: List[Type[Visitor[TConfig]]]
+    config: TConfig
 
     def __init__(self, tree: ast.AST, filename: str) -> None:
         self._tree: ast.AST = tree
@@ -47,11 +74,11 @@ class Plugin:
         if not self._tree or not self._lines:
             self._load_file()
 
-        for visitor in self.visitors:
-            _visitor = visitor()
-            _visitor.visit(self._tree)
+        for visitor_cls in self.visitors:
+            visitor = self._create_visitor(visitor_cls)
+            visitor.visit(self._tree)
 
-            for error in _visitor.errors:
+            for error in visitor.errors:
                 line = self._lines[error.lineno - 1]
                 if not check_noqa(line, error.code):
                     yield self._error(error)
@@ -68,6 +95,50 @@ class Plugin:
             f'{error.code} {error.message}',
             self,
         )
+
+    @classmethod
+    def _create_visitor(
+        cls, visitor_cls: Type[Visitor[TConfig]]
+    ) -> Visitor[TConfig]:
+        if cls.config is None:
+            return visitor_cls()
+
+        return visitor_cls(config=cls.config)
+
+    @classmethod
+    def parse_options(
+        cls,
+        option_manager: OptionManager,
+        options: argparse.Namespace,
+        args: List[str],
+    ) -> None:
+        cls.config = cls.parse_options_to_config(option_manager, options, args)
+
+    @classmethod
+    def parse_options_to_config(  # pylint: disable=unused-argument
+        cls,
+        option_manager: OptionManager,
+        options: argparse.Namespace,
+        args: List[str],
+    ) -> Optional[TConfig]:
+        return None
+
+    @classmethod
+    @contextmanager
+    def test_config(cls, config: TConfig) -> Iterator[None]:
+        """
+        Context manager to add a config to the plugin class for testing.
+
+        Normally flake8 will call `parse_options` on the plugin, which will
+        set the config on the plugin class.  However, this is not the case
+        when creating a plugin manually in tests.  This context manager can
+        be used to pass in a config and clean up afterwards.
+        """
+        cls.config = config
+        try:
+            yield
+        finally:
+            del cls.config
 
 
 def check_noqa(line: str, code: str) -> bool:

--- a/flake8_plugin_utils/utils.py
+++ b/flake8_plugin_utils/utils.py
@@ -21,7 +21,9 @@ def is_true(node: ast.AST) -> bool:
     return _is(node, True)
 
 
-def _error_from_src(visitor_cls: Type[Visitor], src: str) -> Optional[Error]:
+def _error_from_src(
+    visitor_cls: Type[Visitor[Any]], src: str
+) -> Optional[Error]:
     visitor = visitor_cls()
     tree = ast.parse(dedent(src))
     visitor.visit(tree)
@@ -32,7 +34,10 @@ def _error_from_src(visitor_cls: Type[Visitor], src: str) -> Optional[Error]:
 
 
 def assert_error(
-    visitor_cls: Type[Visitor], src: str, expected: Type[Error], **kwargs: Any
+    visitor_cls: Type[Visitor[Any]],
+    src: str,
+    expected: Type[Error],
+    **kwargs: Any,
 ) -> None:
     err = _error_from_src(visitor_cls, src)
     assert err, f'Error "{expected.message}" not found in\n{src}'
@@ -44,6 +49,6 @@ def assert_error(
     ), f'Expected error with message "{expected_message}", got "{err.message}"'
 
 
-def assert_not_error(visitor_cls: Type[Visitor], src: str) -> None:
+def assert_not_error(visitor_cls: Type[Visitor[Any]], src: str) -> None:
     err = _error_from_src(visitor_cls, src)
     assert not err, f'Error "{err.message}" found in\n{src}'  # type: ignore


### PR DESCRIPTION
An alternative take on config implementation.

Basic idea:
* If a plugin writer does not need a config, they simply inherit from `Plugin[None]` and `Visitor[None]`, and everything works as before. Attempts to access the config inside visitors will fail.
* If a config is needed, a plugin writer shall inherit from `Plugin[SomeConfigType]` and `Visitor[SomeConfigType]`, implement `Plugin.add_options` as per Flake8 docs, and override `Plugin.parse_options_to_config` to return the parsed config. Then the visitors will have a `config` property available.